### PR TITLE
Filehandler directurl

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -7033,7 +7033,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 
 					// Bypass loading the asset and just send the user a link to it.
 					if (directLinkUri != null) {
-						res.addHeader("Location", directLinkUri.toString());
+						res.sendRedirect(directLinkUri.toString());
 						return;
 					}
 


### PR DESCRIPTION
This has a basic implementation of downloading S3 content into temp files and then using streaming to deliver wherever needed from CHS. It's a bit hacky, but does avoid using full byte arrays in memory.

To test it for user downloads, return null from getAssetDirectLink.

Improvements to make:

 * Use a property to configure the size threshold (currently hard coded at 100MB)
 * Use a property to decide whether to use direct access URLs
 * Use the CHS-managed modified date for filename or S3 created date (since S3 seems to use a rolling modified date??)
 * Use a property to decide where to put the temp files (currently in Tomcat default temp directory)