### PR TITLE
SAK-30325 - Unwrap HTML files for direct link streaming

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/AbstractContentResource.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/AbstractContentResource.java
@@ -44,7 +44,8 @@ import org.w3c.dom.Element;
  */
 public class AbstractContentResource implements ContentResource{
 	
-	private ContentResource wrapped;
+	// Use package visibility to allow things in impl to get the raw resource
+	ContentResource wrapped;
 	
 	public AbstractContentResource(ContentResource wrapped) {
 		this.wrapped = wrapped;

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -2319,7 +2319,18 @@ public class DbContentService extends BaseContentService
         public URI getDirectLink(ContentResource resource)
         {
         	try {
-        		return fileSystemHandler.getAssetDirectLink(((BaseResourceEdit) resource).m_id, m_bodyPath, ((BaseResourceEdit) resource).m_filePath);
+        		// SAK-30325 - HTML items not being BaseResourceEdits causes a
+        		// ClassCastException here, which gets swallowed and turned into a 404.
+        		// This is an ugly hack because of the necessary casting here (to get m_filePath).
+        		// This is another case where the nested classes and fuzzy boundaries causes
+        		// rather sloppy object orientation. A more complete treatment would reevaluate
+        		// the interfaces, remove the Edits, and extract these classes and casts.
+        		ContentResource rawResource = (resource instanceof WrappedContentResource) ?
+        				((WrappedContentResource) resource).wrapped : resource;
+        		if (!(rawResource instanceof BaseResourceEdit)) {
+        			return null;
+        		}
+        		return fileSystemHandler.getAssetDirectLink(((BaseResourceEdit) rawResource).m_id, m_bodyPath, ((BaseResourceEdit) rawResource).m_filePath);
         	}
         	catch (IOException e) {
         		M_log.debug("No direct link available for resource: " + resource.getId());


### PR DESCRIPTION
Because HTML files use a wrapper class that does not extend from
BaseResourceEdit, and the DbContentService has many places that depend
on casting to read the private m_filePath property, a ClassCastException
was being thrown (and swallowed, and turned into a 404 error) when
attempting to view HTML files.

This change is less than ideal, but it works around the problem by
allowing the wrapped resource to be accessed and cast. A better fix
would rework the relationship between these classes (nesting, casting,
type checking) and firm up better interfaces/base classes.

There is also a safety check added before the cast so any other
ContentResource implementations that make it here will just return null
for the direct link -- causing them to be sent by the server directly.