### PR TITLE
SAK-51535 Gradebook Fix grade override format warning

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -537,13 +537,9 @@ public class ExportPanel extends BasePanel {
 					if (isCustomExport && this.includeCalculatedGrade) {
 						line.add(FormatHelper.formatGradeForDisplay(courseGrade.getCalculatedGrade()));
 					}
-					if (isCustomExport && this.includeGradeOverride) {
-						if (courseGrade.getEnteredGrade() != null) {
-							line.add(FormatHelper.formatGradeForDisplay(courseGrade.getEnteredGrade()));
-						} else {
-							line.add(null);
-						}
-					}
+									if (isCustomExport && this.includeGradeOverride) {
+					line.add(courseGrade.getEnteredGrade());
+				}
 					
 					csvWriter.writeNext(line.toArray(new String[] {}));
 				});

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -2665,10 +2665,15 @@ public class SakaiLTIUtil {
 		// Are we in the default lineitem for the content object?
 		// Check if this is as assignment placement and handle it if it is
 		if ( lineitem_key == null ) {
-			org.sakaiproject.assignment.api.model.Assignment assignment = getAssignment(site, content);
-			if ( assignment != null ) {
-				retval = handleAssignment(assignment, userId, scoreObj);
-				return retval;
+			pushAdvisor(); // Add security advisor to allow access to assignments
+			try {
+				org.sakaiproject.assignment.api.model.Assignment assignment = getAssignment(site, content);
+				if ( assignment != null ) {
+					retval = handleAssignment(assignment, userId, scoreObj);
+					return retval;
+				}
+			} finally {
+				popAdvisor(); // Remove security advisor
 			}
 			title = (String) content.get(LTIService.LTI_TITLE);
 			if (title == null || title.length() < 1) {
@@ -2687,22 +2692,27 @@ public class SakaiLTIUtil {
 			String external_id = gradebookColumn.getExternalId();
 			log.debug("external_id: {} {}", external_id);
 			if ( external_id != null && LineItemUtil.isAssignmentColumn(external_id) ) {
-				org.sakaiproject.assignment.api.AssignmentService assignmentService = ComponentManager.get(org.sakaiproject.assignment.api.AssignmentService.class);
-				org.sakaiproject.assignment.api.model.Assignment assignment;
+				pushAdvisor(); // Add security advisor to allow access to assignments
 				try {
-					org.sakaiproject.assignment.api.AssignmentReferenceReckoner.AssignmentReference assignmentReference = org.sakaiproject.assignment.api.AssignmentReferenceReckoner.reckoner().reference(external_id).reckon();
-					log.debug("assignmentReference.id {}", assignmentReference.getId());
-					assignment = assignmentService.getAssignment(assignmentReference.getId());
-				} catch (Exception e) {
-					assignment = null;
-					log.error("Unexpected error getting assignment: {}", e.toString());
-					log.debug("Stacktrace:", e);
-				}
+					org.sakaiproject.assignment.api.AssignmentService assignmentService = ComponentManager.get(org.sakaiproject.assignment.api.AssignmentService.class);
+					org.sakaiproject.assignment.api.model.Assignment assignment;
+					try {
+						org.sakaiproject.assignment.api.AssignmentReferenceReckoner.AssignmentReference assignmentReference = org.sakaiproject.assignment.api.AssignmentReferenceReckoner.reckoner().reference(external_id).reckon();
+						log.debug("assignmentReference.id {}", assignmentReference.getId());
+						assignment = assignmentService.getAssignment(assignmentReference.getId());
+					} catch (Exception e) {
+						assignment = null;
+						log.error("Unexpected error getting assignment: {}", e.toString());
+						log.debug("Stacktrace:", e);
+					}
 
-				if ( assignment != null ) {
-					log.debug("Gradebook column is owned by assignment: {}", assignment.getId());
-					retval = handleAssignment(assignment, userId, scoreObj);
-					return retval;
+					if ( assignment != null ) {
+						log.debug("Gradebook column is owned by assignment: {}", assignment.getId());
+						retval = handleAssignment(assignment, userId, scoreObj);
+						return retval;
+					}
+				} finally {
+					popAdvisor(); // Remove security advisor
 				}
 			}
 			title = gradebookColumn.getName();
@@ -2831,6 +2841,7 @@ public class SakaiLTIUtil {
 		org.sakaiproject.assignment.api.AssignmentService assignmentService = ComponentManager.get(org.sakaiproject.assignment.api.AssignmentService.class);
 		org.sakaiproject.user.api.PreferencesService preferencesService  = ComponentManager.get(org.sakaiproject.user.api.PreferencesService.class);
 		UserTimeService userTimeService = ComponentManager.get(UserTimeService.class);
+		org.sakaiproject.site.api.SiteService siteService = ComponentManager.get(org.sakaiproject.site.api.SiteService.class);
 
 		String activityProgress = scoreObj.activityProgress != null ? scoreObj.activityProgress : Score.ACTIVITY_COMPLETED ;
 		String gradingProgress = scoreObj.gradingProgress != null ? scoreObj.gradingProgress : Score.GRADING_FULLYGRADED;
@@ -2846,10 +2857,51 @@ public class SakaiLTIUtil {
 
 		pushAdvisor();
 		try {
-			org.sakaiproject.assignment.api.model.AssignmentSubmission submission = assignmentService.getSubmission(a.getId(), user);
-			if ( submission == null ) {
-				submission = assignmentService.addSubmission(a.getId(), user.getId());
+			org.sakaiproject.assignment.api.model.AssignmentSubmission submission = null;
+			
+			// For group assignments, we need to find the group the user belongs to
+			if (a.getIsGroup()) {
+				log.debug("This is a group assignment {}", a.getId());
+				String context = a.getContext();
+				try {
+					org.sakaiproject.site.api.Site site = siteService.getSite(context);
+					// Find all groups user is a member of that are also assignment groups
+					Set<String> assignmentGroups = a.getGroups();
+					Collection<org.sakaiproject.site.api.Group> userGroups = site.getGroupsWithMember(userId);
+					
+					// Find the first matching group between assignment groups and user groups
+					String groupId = null;
+					for (org.sakaiproject.site.api.Group group : userGroups) {
+						if (assignmentGroups.contains(group.getReference())) {
+							groupId = group.getId();
+							break;
+						}
+					}
+					
+					if (groupId != null) {
+						log.debug("Found group for user: groupId={} userId={}", groupId, userId);
+						// Try to get existing group submission
+						submission = assignmentService.getSubmission(a.getId(), groupId);
+						if (submission == null) {
+							// Create new submission for the group
+							submission = assignmentService.addSubmission(a.getId(), groupId);
+						}
+					} else {
+						log.warn("No matching group found for user in group assignment: userId={}, assignmentId={}", userId, a.getId());
+					}
+				} catch (org.sakaiproject.exception.IdUnusedException e) {
+					log.warn("Site not found: {}, {}", context, e.toString());
+				}
 			}
+			
+			// If this isn't a group assignment, or we couldn't find a group, get/create individual submission
+			if (submission == null) {
+				submission = assignmentService.getSubmission(a.getId(), user);
+				if (submission == null) {
+					submission = assignmentService.addSubmission(a.getId(), user.getId());
+				}
+			}
+			
 			log.debug("submission: {} {} {}", scaledGrade, user.getId(), submission);
 
 			StringBuilder logEntry = new StringBuilder();
@@ -2882,7 +2934,11 @@ public class SakaiLTIUtil {
 			submission.setUserSubmission(true);
 			submission.setFeedbackComment(scoreObj.comment);
 			submission.setDateModified(now);
-			submission.getSubmitters().stream().filter(s -> s.getSubmitter().equals(userId)).findFirst().ifPresent(s -> s.setSubmittee(true));
+			
+			// For individual submissions or when we know the specific user
+			if (!a.getIsGroup() || submission.getSubmitters().stream().anyMatch(s -> s.getSubmitter().equals(userId))) {
+				submission.getSubmitters().stream().filter(s -> s.getSubmitter().equals(userId)).findFirst().ifPresent(s -> s.setSubmittee(true));
+			}
 
 			// SAK-46548 - Any new LTI grade unchecks assignments "released to student"
 			submission.setGradeReleased(false);


### PR DESCRIPTION
Remove `FormatHelper.formatGradeForDisplay()` from Grade Override export to prevent server warnings for letter grades.