### PR TITLE
NOJIRA: centralize group override check

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -1274,7 +1274,7 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
         options.put(GRADE_SUBMISSION_GRADE, grade);
 
         // check for grade overrides
-        if (assignment.getIsGroup()) {
+        if (AssignmentToolUtils.allowGroupOverrides(assignment, assignmentService)) {
             submission.getSubmitters().forEach(s -> {
 
                 String ug = StringUtils.trimToNull((String) params.get(GRADE_SUBMISSION_GRADE + "_" + s.getSubmitter()));

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4133,7 +4133,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 setScoringAgentProperties(context, a, s, true);
 
                 // try to put in grade overrides (not applicable when anonymous grading is enabled)
-                if (a.getIsGroup() && !assignmentService.assignmentUsesAnonymousGrading(a)) {
+                if (AssignmentToolUtils.allowGroupOverrides(a, assignmentService)) {
                     context.put("ownerGroupId", s.getGroupId());
                     Map<String, Object> grades = new HashMap<>();
                     for (String userId : users.keySet()) {
@@ -5193,7 +5193,7 @@ public class AssignmentAction extends PagedResourceActionII {
             }
 
             // try to put in grade overrides for list context (not when anonymous grading)
-            if (assignment.getIsGroup() && !assignmentService.assignmentUsesAnonymousGrading(assignment)) {
+            if (AssignmentToolUtils.allowGroupOverrides(assignment, assignmentService)) {
                 Map<String, Object> ugrades = new HashMap<>();
                 Map<String, String> p = assignment.getProperties();
                 for (SubmitterSubmission ss : userSubmissions) {
@@ -11556,12 +11556,12 @@ public class AssignmentAction extends PagedResourceActionII {
                 state.setAttribute(GRADE_SUBMISSION_GRADE, grade);
 
                 // populate grade overrides if they exist (skip when anonymous grading)
-                if (a.getIsGroup() && !assignmentService.assignmentUsesAnonymousGrading(a)) {
-	                for (AssignmentSubmissionSubmitter submitter : s.getSubmitters()) {
-	                    String gradeOverride = assignmentService.getGradeForSubmitter(s, submitter.getSubmitter());
-	                    if (!StringUtils.equals(grade, gradeOverride)) {
-	                        state.setAttribute(GRADE_SUBMISSION_GRADE + "_" + submitter.getSubmitter(), gradeOverride);
-	                    }
+                if (AssignmentToolUtils.allowGroupOverrides(a, assignmentService)) {
+                        for (AssignmentSubmissionSubmitter submitter : s.getSubmitters()) {
+                            String gradeOverride = assignmentService.getGradeForSubmitter(s, submitter.getSubmitter());
+                            if (!StringUtils.equals(grade, gradeOverride)) {
+                                state.setAttribute(GRADE_SUBMISSION_GRADE + "_" + submitter.getSubmitter(), gradeOverride);
+                            }
 	                }
                 }
 
@@ -12558,7 +12558,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 }
 
                 // check for grade overrides (not applicable when anonymous grading)
-                if (a.getIsGroup() && !assignmentService.assignmentUsesAnonymousGrading(a)) {
+                if (AssignmentToolUtils.allowGroupOverrides(a, assignmentService)) {
                     HashMap<String, String> scaledValues = new HashMap<String, String>();
                     Set<AssignmentSubmissionSubmitter> submitters = submission.getSubmitters();
                     for (AssignmentSubmissionSubmitter submitter : submitters) {

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentToolUtils.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentToolUtils.java
@@ -97,6 +97,10 @@ public class AssignmentToolUtils {
 
     private static ResourceLoader rb = new ResourceLoader("assignment");
 
+    public static boolean allowGroupOverrides(Assignment a, AssignmentService assignmentService) {
+        return a.getIsGroup() && !assignmentService.assignmentUsesAnonymousGrading(a);
+    }
+
     /**
      * scale the point value by "factor" if there is a valid point grade
      */
@@ -334,7 +338,7 @@ public class AssignmentToolUtils {
                 }
             }
 
-            if (a.getIsGroup()) {
+            if (allowGroupOverrides(a, assignmentService)) {
                 // group project only set a grade override for submitters
                 for (AssignmentSubmissionSubmitter submitter : submission.getSubmitters()) {
                     String submitterGradeOverride = StringUtils.trimToNull((String) options.get(GRADE_SUBMISSION_GRADE + "_" + submitter.getSubmitter()));

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -511,7 +511,7 @@
                                 <div class="row-override">
                                     <label>$formattedText.escapeHtml($!submitterName)</label>
                                     <div class="shorttext">
-                                        <span$tlang.getString("gen.grade.override")</span>
+                                        <span>$tlang.getString("gen.grade.override")</span>
                                         <select name="$group_name_grade" id="grade">
                                             <option value=""#if($!group_value_grade.equals(
                                                 ""))selected="selected"#end>$tlang.getString(


### PR DESCRIPTION
## Summary
- fix malformed grading override span in instructor submission template
- centralize group override check via `allowGroupOverrides` helper and reuse in action and entity provider

## Testing
- `mvn -q -pl assignment/tool -am test` *(fails: Unresolveable build extension: Plugin org.sakaiproject.maven.plugins:sakai:1.4.5)*
- `mvn -q -pl assignment/tool -am -DskipTests package` *(fails: Unresolveable build extension: Plugin org.sakaiproject.maven.plugins:sakai:1.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ed57f7188328994f5537bca1a288