### PR TITLE
SAK-00000 Assignments handle null category definitions

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -13434,8 +13434,12 @@ public class AssignmentAction extends PagedResourceActionII {
             // Unassigned option (-1) shown first
             catTable.put(-1L, rb.getString("grading.unassigned"));
 
-            gradingService.getCategoryDefinitions(gradebookUid, gradebookUid).stream()
-                .forEach(c -> catTable.put(c.getId(), c.getName()));
+            List<CategoryDefinition> categoryDefinitions = gradingService.getCategoryDefinitions(gradebookUid, gradebookUid);
+            if (categoryDefinitions != null) {
+                for (CategoryDefinition c : categoryDefinitions) {
+                    catTable.put(c.getId(), c.getName());
+                }
+            }
         }
         return catTable;
     }


### PR DESCRIPTION
## Summary
- Avoid NPE when gradebook has no categories

## Testing
- `mvn -q -pl assignment/tool -am test` *(fails: Unresolveable build extension: Plugin org.sakaiproject.maven.plugins:sakai:1.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fe1461c88328befef52b89f2e2d4