### PR TITLE
SAK-00000: Rename categoryList variable to categoryKeys in AssignmentAction

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -3849,8 +3849,8 @@ public class AssignmentAction extends PagedResourceActionII {
                 context.put("value_Category", state.getAttribute(NEW_ASSIGNMENT_CATEGORY));
 
                 // Preserve insertion order (matches Gradebook Settings order)
-                List<Long> categoryList = new ArrayList<>(categoryTable.keySet());
-                context.put("categoryKeys", categoryList);
+                List<Long> categoryKeys = new ArrayList<>(categoryTable.keySet());
+                context.put("categoryKeys", categoryKeys);
                 context.put("categoryTable", categoryTable);
             } else {
                 context.put("value_totalCategories", Long.valueOf(0));


### PR DESCRIPTION
## Summary
- rename `categoryList` variable to `categoryKeys`
- update context map to use `categoryKeys`

## Testing
- `mvn -pl assignment/tool -am test` *(fails: Unresolveable build extension org.sakaiproject.maven.plugins:sakai:1.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fe6dc9808328b33ffcbfc44727c1