### PR TITLE
NOJIRA assignments enforce null checks for group overrides

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentToolUtils.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentToolUtils.java
@@ -97,7 +97,18 @@ public class AssignmentToolUtils {
 
     private static ResourceLoader rb = new ResourceLoader("assignment");
 
+    /**
+     * Returns {@code true} when per-submitter grade overrides are permitted: the assignment is a group
+     * assignment and anonymous grading is NOT enabled for that assignment.
+     *
+     * @param a the assignment to check
+     * @param assignmentService the AssignmentService used to determine anonymous grading
+     * @return {@code true} if the assignment is a group assignment and anonymous grading is disabled
+     * @throws NullPointerException if {@code a} or {@code assignmentService} is {@code null}
+     */
     public static boolean allowGroupOverrides(Assignment a, AssignmentService assignmentService) {
+        Objects.requireNonNull(a, "assignment");
+        Objects.requireNonNull(assignmentService, "assignmentService");
         return a.getIsGroup() && !assignmentService.assignmentUsesAnonymousGrading(a);
     }
 
@@ -342,7 +353,8 @@ public class AssignmentToolUtils {
                 // group project only set a grade override for submitters
                 for (AssignmentSubmissionSubmitter submitter : submission.getSubmitters()) {
                     String submitterGradeOverride = StringUtils.trimToNull((String) options.get(GRADE_SUBMISSION_GRADE + "_" + submitter.getSubmitter()));
-                    if (!StringUtils.equals(submitterGradeOverride, submitter.getGrade())) {
+                    String current = StringUtils.trimToNull(submitter.getGrade());
+                    if (!StringUtils.equals(submitterGradeOverride, current)) {
                         submitter.setGrade(submitterGradeOverride);
                     }
                 }


### PR DESCRIPTION
## Summary
- add Javadoc and null checks to AssignmentToolUtils.allowGroupOverrides
- trim submitter grade value before comparison to avoid whitespace-only updates

## Testing
- `mvn -q -pl assignment/tool -am test` *(fails: Unresolveable build extension: Plugin org.sakaiproject.maven.plugins:sakai:1.4.5 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c301fac7e883289443eaf0da5aaa76