### PR TITLE
Fix IllegalToken message configuration for no-var checkstyle rule

### DIFF
--- a/master/checkstyle/no-var.xml
+++ b/master/checkstyle/no-var.xml
@@ -14,7 +14,7 @@
     <module name="IllegalToken">
       <!-- Forbid the `var` token used for local variable type inference (Java 10+) -->
       <property name="tokens" value="LITERAL_VAR"/>
-      <property name="message" value="Do not use 'var' (local variable type inference); declare explicit types."/>
+      <message key="illegal.token" value="Do not use 'var' (local variable type inference); declare explicit types."/>
     </module>
   </module>
 </module>


### PR DESCRIPTION
## Summary
- replace the unsupported message property in the no-var checkstyle rule with a message element so the configuration loads

## Testing
- mvn -pl master checkstyle:check -DskipTests

------
https://chatgpt.com/codex/tasks/task_e_68dfca806398832889f008642040f643