### PR TITLE
Fix Ehcache jar reference in Tomcat configuration

### DIFF
--- a/docker/tomcat/conf/catalina.properties
+++ b/docker/tomcat/conf/catalina.properties
@@ -305,7 +305,7 @@ dist-datatables-rowgroup-*.jar,\
 dom-walk-*.jar,\
 dompurify-*.jar,\
 dropzone-*.jar,\
-ehcache-core-*.jar,\
+ehcache-*.jar,\
 elasticsearch-api-*.jar,\
 elfinder-*.jar,\
 elfinder-servlet-2-*.jar,\


### PR DESCRIPTION
## Summary
- update the Tomcat catalina.properties classpath include to match the net.sf.ehcache:ehcache artifact name

## Testing
- `mvn -pl master dependency:tree -Dincludes=net.sf.ehcache:ehcache -DskipTests`

------
https://chatgpt.com/codex/tasks/task_e_68dfe55467088328a6279793c1c4a5af