### PR TITLE
NOJIRA: Remove redundant spring-data-jpa dependency and clear caches

### DIFF
--- a/hierarchy/impl/pom.xml
+++ b/hierarchy/impl/pom.xml
@@ -135,11 +135,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Needed because SpringCrudRepositoryImpl references Page/Pageable -->
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-jpa</artifactId>
-        </dependency>
         <!-- Jackson required by SpringCrudRepositoryImpl and MapperFactory -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/hierarchy/impl/src/java/org/sakaiproject/hierarchy/impl/HierarchyServiceImpl.java
+++ b/hierarchy/impl/src/java/org/sakaiproject/hierarchy/impl/HierarchyServiceImpl.java
@@ -447,6 +447,8 @@ public class HierarchyServiceImpl implements HierarchyService {
 
         // save the node meta data
         nodeMetaRepository.save(metaData);
+        // Invalidate single-node cache so subsequent reads see updated metadata
+        cache.remove("n" + nodeId);
 
         return HierarchyImplUtils.makeNode(metaData);
     }
@@ -472,6 +474,8 @@ public class HierarchyServiceImpl implements HierarchyService {
 
         // save the node meta data
         nodeMetaRepository.save(metaData);
+        // Invalidate single-node cache so subsequent reads see updated disabled flag
+        cache.remove("n" + nodeId);
 
         return HierarchyImplUtils.makeNode(metaData);
 
@@ -558,6 +562,10 @@ public class HierarchyServiceImpl implements HierarchyService {
                 pNodes.add(pNode);
             }
 
+            // Invalidate cached child-node sets for all affected nodes
+            for (HierarchyPersistentNode n : pNodes) {
+                cache.remove("cn" + n.getId());
+            }
             nodeRepository.saveAll(pNodes);
         }
 
@@ -652,6 +660,10 @@ public class HierarchyServiceImpl implements HierarchyService {
                 pNodes.add(pNode);
             }
 
+            // Invalidate cached child-node sets for all affected nodes
+            for (HierarchyPersistentNode n : pNodes) {
+                cache.remove("cn" + n.getId());
+            }
             nodeRepository.saveAll(pNodes);
 
         }


### PR DESCRIPTION
## Summary
- remove the direct spring-data-jpa dependency from hierarchy-impl since it comes from hierarchy-api
- clear single-node caches when node metadata or disabled status is updated
- invalidate cached child-node sets when child relations change

## Testing
- mvn -pl hierarchy/impl -am -DskipTests dependency:tree -Dincludes=org.springframework.data:spring-data-jpa

------
https://chatgpt.com/codex/tasks/task_e_68e3f8fac5e0832880a57ac9392b055c