### PR TITLE
SAK-52023 Remove profile2 tool references from defaults

### DIFF
--- a/entitybroker/core-providers/pom.xml
+++ b/entitybroker/core-providers/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>sakai-privacy-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.sakaiproject.profile2</groupId>
+            <artifactId>profile2-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.sakaiproject</groupId>
             <artifactId>reflectutils</artifactId>
         </dependency>

--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/UserEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/UserEntityProvider.java
@@ -42,9 +42,7 @@ import org.sakaiproject.entitybroker.entityprovider.search.Restriction;
 import org.sakaiproject.entitybroker.entityprovider.search.Search;
 import org.sakaiproject.entitybroker.providers.model.EntityUser;
 import org.sakaiproject.entitybroker.util.AbstractEntityProvider;
-import org.sakaiproject.exception.IdUnusedException;
-import org.sakaiproject.site.api.Site;
-import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.profile2.api.ProfileService;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserAlreadyDefinedException;
 import org.sakaiproject.user.api.UserDirectoryService;
@@ -67,9 +65,9 @@ public class UserEntityProvider extends AbstractEntityProvider implements CoreEn
     private static final String ID_PREFIX = "id=";
 
     private UserDirectoryService userDirectoryService;
-    private SiteService siteService;
     private DeveloperHelperService developerHelperService;
     private ServerConfigurationService serverConfigurationService;
+    private ProfileService profileService;
 
     public static String PREFIX = "user";
     public String getEntityPrefix() {
@@ -593,18 +591,7 @@ public class UserEntityProvider extends AbstractEntityProvider implements CoreEn
      * @return <code>true</code> if the current user has the profile tool in their My Workspace.
      */
     private boolean hasProfile() {
-        boolean hasProfile = false;
-        String currentUserId = developerHelperService.getCurrentUserId();
-        if (currentUserId != null) {
-            String userSiteId = siteService.getUserSiteId(currentUserId);
-            try {
-                Site userSite = siteService.getSite(userSiteId);
-                hasProfile = userSite.getToolForCommonId("sakai.profile2") != null;
-            } catch (IdUnusedException e) {
-                // Ignore
-            }
-        }
-        return hasProfile;
+        return profileService != null;
     }
 
     /**

--- a/entitybroker/core-providers/src/webapp/WEB-INF/applicationContext.xml
+++ b/entitybroker/core-providers/src/webapp/WEB-INF/applicationContext.xml
@@ -10,7 +10,7 @@
         <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
         <property name="developerHelperService" ref="org.sakaiproject.entitybroker.DeveloperHelperService"/>
         <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
-        <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+        <property name="profileService" ref="org.sakaiproject.profile2.api.ProfileService"/>
     </bean>
 
     <bean parent="org.sakaiproject.entitybroker.entityprovider.AbstractEntityProvider"

--- a/help/help/src/sakai_screensteps_profileUserGuide/whatistheProfiletool.html
+++ b/help/help/src/sakai_screensteps_profileUserGuide/whatistheProfiletool.html
@@ -3,7 +3,7 @@
 <head>
 <title>What is the Profile tool?</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta content="sakai.profile2" name="description">
+<meta content="sakai.profile" name="description">
 <link href="../css/help.css" media="all" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/webjars/fontawesome/4.7.0/css/font-awesome.min.css" media="screen" rel="stylesheet">
 <link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">

--- a/help/help/src/sakai_toc/help.xml
+++ b/help/help/src/sakai_toc/help.xml
@@ -5572,7 +5572,7 @@
       <value>/sakai_screensteps_profileUserGuide/whatistheProfiletool.html</value>
     </property>
     <property name="defaultForTool">
-      <value>sakai.profile2</value>
+      <value>sakai.profile</value>
     </property>
   </bean>
   <bean id="howdoIsetupmyprofile" class="org.sakaiproject.component.app.help.model.ResourceBean">

--- a/kernel/kernel-impl/src/main/sql/hsqldb/sakai_site.sql
+++ b/kernel/kernel-impl/src/main/sql/hsqldb/sakai_site.sql
@@ -314,8 +314,6 @@ INSERT INTO SAKAI_SITE_TOOL VALUES('!user-120', '!user-100', '!user', 'sakai.ifr
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-130', '!user-100', '!user', 'sakai.summary.calendar', 2, 'Calendar', '0,1' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-140', '!user-100', '!user', 'sakai.synoptic.announcement', 2, 'Recent Announcements', '1,1' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-145', '!user-100', '!user', 'sakai.synoptic.messagecenter', 2, 'Unread Messages and Forums', '1,1' );
-INSERT INTO SAKAI_SITE_PAGE VALUES('!user-150', '!user', 'Profile', '0', 2, '0' );
-INSERT INTO SAKAI_SITE_TOOL VALUES('!user-165', '!user-150', '!user', 'sakai.profile2', 1, 'Profile', NULL );
 INSERT INTO SAKAI_SITE_PAGE VALUES('!user-200', '!user', 'Membership', '0', 3, '0' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-210', '!user-200', '!user', 'sakai.membership', 1, 'Membership', NULL );
 INSERT INTO SAKAI_SITE_PAGE VALUES('!user-300', '!user', 'Calendar', '0', 4, '0' );

--- a/kernel/kernel-impl/src/main/sql/mysql/sakai_site.sql
+++ b/kernel/kernel-impl/src/main/sql/mysql/sakai_site.sql
@@ -336,8 +336,6 @@ INSERT INTO SAKAI_SITE_TOOL VALUES('!user-120', '!user-100', '!user', 'sakai.ifr
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-130', '!user-100', '!user', 'sakai.summary.calendar', 2, 'Calendar', '0,1' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-140', '!user-100', '!user', 'sakai.synoptic.announcement', 2, 'Recent Announcements', '1,1' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-145', '!user-100', '!user', 'sakai.synoptic.messagecenter', 2, 'Unread Messages and Forums', '1,1' );
-INSERT INTO SAKAI_SITE_PAGE VALUES('!user-150', '!user', 'Profile', '0', 2, '0' );
-INSERT INTO SAKAI_SITE_TOOL VALUES('!user-165', '!user-150', '!user', 'sakai.profile2', 1, 'Profile', NULL );
 INSERT INTO SAKAI_SITE_PAGE VALUES('!user-200', '!user', 'Membership', '0', 3, '0' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-210', '!user-200', '!user', 'sakai.membership', 1, 'Membership', NULL );
 INSERT INTO SAKAI_SITE_PAGE VALUES('!user-300', '!user', 'Calendar', '0', 4, '0' );

--- a/kernel/kernel-impl/src/main/sql/oracle/sakai_site.sql
+++ b/kernel/kernel-impl/src/main/sql/oracle/sakai_site.sql
@@ -353,8 +353,6 @@ INSERT INTO SAKAI_SITE_TOOL VALUES('!user-120', '!user-100', '!user', 'sakai.ifr
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-130', '!user-100', '!user', 'sakai.summary.calendar', 2, 'Calendar', '0,1' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-140', '!user-100', '!user', 'sakai.synoptic.announcement', 2, 'Recent Announcements', '1,1' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-145', '!user-100', '!user', 'sakai.synoptic.messagecenter', 2, 'Unread Messages and Forums', '1,1' );
-INSERT INTO SAKAI_SITE_PAGE VALUES('!user-150', '!user', 'Profile', '0', 2, '0' );
-INSERT INTO SAKAI_SITE_TOOL VALUES('!user-165', '!user-150', '!user', 'sakai.profile2', 1, 'Profile', NULL );
 INSERT INTO SAKAI_SITE_PAGE VALUES('!user-200', '!user', 'Membership', '0', 3, '0' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-210', '!user-200', '!user', 'sakai.membership', 1, 'Membership', NULL );
 INSERT INTO SAKAI_SITE_PAGE VALUES('!user-300', '!user', 'Calendar', '0', 4, '0' );

--- a/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -1199,14 +1199,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 
     @Override
     public String getProfileToolLink(String otherUserId, String siteId) {
-        try {
-            Site site = siteService.getSite(siteService.getUserSiteId(getCurrentUserId()));
-            return Optional.ofNullable(site.getToolForCommonId("sakai.profile2"))
-                    .map(tc -> site.getUrl() + "/tool/" + tc.getId() + (StringUtils.isNotBlank(otherUserId) ? "/viewprofile/" + otherUserId + "?fromSiteId=" + siteId : ""))
-                    .orElse(StringUtils.EMPTY);
-        } catch (Exception e) {
-            log.warn("Could not create profile tool link for site: {}, {}", siteId, e.toString());
-        }
+        log.debug("Profile tool link requested for user {} in site {} but no profile tool is available", otherUserId, siteId);
         return StringUtils.EMPTY;
     }
 

--- a/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
+++ b/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
@@ -542,9 +542,9 @@
         <event eventId="sitestats.track" selected="false"/>
         <eventParserTip for="contextId" separator="/" index="2"/>
     </tool>
-    <!-- profile 2 -->
-    <tool 
-        toolId="sakai.profile2"
+    <!-- account/profile -->
+    <tool
+        toolId="sakai.profile"
         selected="false">
         <event eventId="profile.view.own" selected="false"/>
         <event eventId="profile.view.other" selected="false"/>

--- a/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiScript.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiScript.java
@@ -3068,7 +3068,7 @@ public class SakaiScript extends AbstractWebService {
      *
      * @param pagelayout single or double column (0 or 1). Any other value will revert to 0.
      * @param sessionid  the id of a valid session for the admin user
-     * @param toolid     the id of the tool you want to add (ie sakai.profile2)
+     * @param toolid     the id of the tool you want to add (ie sakai.announcements)
      * @param pagetitle  the title of the page shown in the site navigation
      * @param tooltitle  the title of the tool shown in the main portlet
      * @param position   integer specifying the position within other pages on the site (0 means top, for right at the bottom a large enough number, ie 99)
@@ -3754,7 +3754,7 @@ public class SakaiScript extends AbstractWebService {
                 toolIdAttr.setNodeValue(toolConfig.getId());
                 toolNode.setAttributeNode(toolIdAttr);
 
-                //registration (eg sakai.profile2)
+                //registration (eg sakai.announcements)
                 Element toolIdNode = dom.createElement("tool-id");
                 toolIdNode.appendChild(dom.createTextNode(toolConfig.getToolId()));
                 toolNode.appendChild(toolIdNode);
@@ -3905,7 +3905,7 @@ public class SakaiScript extends AbstractWebService {
      * @param pagelayout if you want the page to be single or double column (0 or 1). Any other value will revert to 0.
      * @param sessionid  the id of a valid session for the admin user
      * @param siteid     the id of the site to add the page to
-     * @param toolid     the id of the tool you want to add (ie sakai.profile2)
+     * @param toolid     the id of the tool you want to add (ie sakai.announcements)
      * @param pagetitle  the desired title for the page shown in the site navigation. If null, will use default from tool configuration.
      * @param tooltitle  the desired title for the tool shown in the main portlet.  If null, will use default from tool configuration. Custom tool titles only respected if you also have a custom page title.
      * @param position   integer specifying the position of this page within other pages on the site (0 means top, for right at the bottom a large enough number, ie 99)


### PR DESCRIPTION
## Summary
- stop adding the removed Profile2 tool to freshly built !user sites across all database SQL scripts
- swap the entity broker UserEntityProvider over to the profile service instead of looking for sakai.profile2, updating its Spring wiring, POM dependency and unit tests
- guard roster and reporting/doc assets against the retired tool id by returning no profile link, renaming the SiteStats tool mapping and adjusting help / web service references

## Testing
- mvn -pl entitybroker/core-providers -am -Dtest=UserEntityProviderRestrictedViewTest -Dsurefire.failIfNoSpecifiedTests=false test

------
https://chatgpt.com/codex/tasks/task_e_68e7e3d29b7c8328b88b1e60d13af750