### PR TITLE
NOJIRA: Guard assignment instructions null check

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_assignment.vm
@@ -80,9 +80,10 @@
 				<h4 class="card-title mb-0">$tlang.getString("gen.assinf")</h4>
 			</div>
 			<div class="card-body">
-				#if ($assignment.Instructions.length()>0)
-					$formattedText.escapeHtmlFormattedText($assignment.Instructions)
-				#end
+                               #set ($assignmentInstructions = $!assignment.Instructions)
+                               #if ($assignmentInstructions && $assignmentInstructions.length() > 0)
+                                       $formattedText.escapeHtmlFormattedText($assignmentInstructions)
+                               #end
 				
 				## assignment attachment
 				#attachmentFragment($assignment.Attachments $assignmentAttachmentReferences $!decoratedUrlMap false)


### PR DESCRIPTION
## Summary
- guard against null assignment instructions before checking their length in the student view template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7e7757408832891dedf2e0b1ecf75