### PR TITLE
NOJIRA: Prevent assignment feed warning for missing gradebook association

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -1959,7 +1959,7 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
                     }
                 }
             } else {
-                log.warn("The property \"prop_new_assignment_add_to_gradebook\" is null for the assignment feed");
+                log.debug("The property \"prop_new_assignment_add_to_gradebook\" is null for the assignment feed");
             }
 
             this.attachments = a.getAttachments().stream().map(att -> {


### PR DESCRIPTION
## Summary
- downgrade the log when assignments without gradebook associations are serialized for the entity feed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7e83b9a088328810442bf1bf35fa9