### PR TITLE
SAK-00000 Align ADLDuration units with existing data

### DIFF
--- a/scormplayer/scorm-api/src/java/org/adl/sequencer/ADLDuration.java
+++ b/scormplayer/scorm-api/src/java/org/adl/sequencer/ADLDuration.java
@@ -46,9 +46,9 @@ public class ADLDuration implements Serializable, IDuration {
     private long id;
 
     /**
-	 * The duration being tracked in milliseconds
-	 */
-	public long mDuration = 0;
+         * The duration being tracked in seconds to match persisted data
+         */
+        public long mDuration = 0;
 
 	/**
 	 * Default constructor for the <code>ADLDuration</code> class.  Sets the 
@@ -85,7 +85,7 @@ public class ADLDuration implements Serializable, IDuration {
                     log.warn("  Invalid Format ::  {} // {}", iFormat, iValue);
                 }
 
-                mDuration = (long) (secs * 1000.0);
+                mDuration = Math.round(secs);
                 break;
 
             }
@@ -121,8 +121,8 @@ public class ADLDuration implements Serializable, IDuration {
                         totalSeconds += Long.parseLong(sec);
                     }
 
-                    // store internally as milliseconds
-                    mDuration = totalSeconds * 1000;
+                    // store internally as seconds to align with persisted data
+                    mDuration = totalSeconds;
                 } else {
                     log.debug(" ERROR : Invalid format  --> {}", iValue);
                 }
@@ -217,7 +217,7 @@ public class ADLDuration implements Serializable, IDuration {
         switch (iFormat) {
 
             case FORMAT_SECONDS: {
-                double sec = mDuration / 1000.0;
+                double sec = mDuration;
                 out = Double.valueOf(sec).toString();
                 break;
             }
@@ -228,7 +228,7 @@ public class ADLDuration implements Serializable, IDuration {
                 countMin = 0;
                 countSec = 0;
 
-                temp = mDuration / 1000;
+                temp = mDuration;
 
                 // Compute hours, minutes, seconds for any non-negative duration
                 if (temp >= 3600) {

--- a/scormplayer/scorm-api/src/test/org/adl/sequencer/ADLDurationTest.java
+++ b/scormplayer/scorm-api/src/test/org/adl/sequencer/ADLDurationTest.java
@@ -1,0 +1,26 @@
+package org.adl.sequencer;
+
+import junit.framework.TestCase;
+
+public class ADLDurationTest extends TestCase {
+
+    public void testSchemaDurationStoresSeconds() {
+        ADLDuration duration = new ADLDuration(IDuration.FORMAT_SCHEMA, "PT1H2M3S");
+
+        assertEquals(3723L, duration.mDuration);
+        assertEquals("PT1H2M3S", duration.format(IDuration.FORMAT_SCHEMA));
+        assertEquals("3723.0", duration.format(IDuration.FORMAT_SECONDS));
+    }
+
+    public void testLegacySecondBasedDurationsRemainCompatible() {
+        ADLDuration legacy = new ADLDuration();
+        legacy.mDuration = 3661L; // value persisted prior to the schema change (seconds)
+
+        ADLDuration fresh = new ADLDuration(IDuration.FORMAT_SCHEMA, "PT1H1M1S");
+
+        assertEquals("PT1H1M1S", legacy.format(IDuration.FORMAT_SCHEMA));
+        assertEquals("PT1H1M1S", fresh.format(IDuration.FORMAT_SCHEMA));
+        assertEquals("3661.0", legacy.format(IDuration.FORMAT_SECONDS));
+        assertEquals(IDuration.EQ, legacy.compare(fresh));
+    }
+}

--- a/scormplayer/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLDuration.java
+++ b/scormplayer/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLDuration.java
@@ -46,9 +46,9 @@ public class ADLDuration implements Serializable, IDuration {
 	private static final long serialVersionUID = 1L;
 
     /**
-	 * The duration being tracked in milliseconds
-	 */
-	public long mDuration = 0;
+         * The duration being tracked in seconds to match persisted data
+         */
+        public long mDuration = 0;
 
 	/**
 	 * Default constructor for the <code>ADLDuration</code> class.  Sets the 
@@ -85,7 +85,7 @@ public class ADLDuration implements Serializable, IDuration {
                     log.warn("  Invalid Format ::  {} // {}", iFormat, iValue);
                 }
 
-                mDuration = (long) (secs * 1000.0);
+                mDuration = Math.round(secs);
                 break;
             }
             case FORMAT_SCHEMA: {
@@ -120,8 +120,8 @@ public class ADLDuration implements Serializable, IDuration {
                         totalSeconds += Long.parseLong(sec);
                     }
 
-                    // store internally as milliseconds
-                    mDuration = totalSeconds * 1000;
+                    // store internally as seconds to align with persisted data
+                    mDuration = totalSeconds;
                 } else {
                     log.warn("Invalid schema duration format: {}", iValue);
                 }
@@ -199,7 +199,7 @@ public class ADLDuration implements Serializable, IDuration {
         switch (iFormat) {
 
             case FORMAT_SECONDS: {
-                double sec = mDuration / 1000.0;
+                double sec = mDuration;
                 out = Double.valueOf(sec).toString();
                 break;
             }
@@ -210,7 +210,7 @@ public class ADLDuration implements Serializable, IDuration {
                 countMin = 0;
                 countSec = 0;
 
-                temp = mDuration / 1000;
+                temp = mDuration;
 
                 // Compute hours, minutes, seconds for any non-negative duration
                 if (temp >= 3600) {

--- a/scormplayer/scorm-impl/adl/src/test/org/adl/sequencer/impl/ADLDurationTest.java
+++ b/scormplayer/scorm-impl/adl/src/test/org/adl/sequencer/impl/ADLDurationTest.java
@@ -1,0 +1,27 @@
+package org.adl.sequencer.impl;
+
+import junit.framework.TestCase;
+import org.adl.sequencer.IDuration;
+
+public class ADLDurationTest extends TestCase {
+
+    public void testSchemaDurationStoresSeconds() {
+        ADLDuration duration = new ADLDuration(IDuration.FORMAT_SCHEMA, "PT1H2M3S");
+
+        assertEquals(3723L, duration.mDuration);
+        assertEquals("PT1H2M3S", duration.format(IDuration.FORMAT_SCHEMA));
+        assertEquals("3723.0", duration.format(IDuration.FORMAT_SECONDS));
+    }
+
+    public void testLegacySecondBasedDurationsRemainCompatible() {
+        ADLDuration legacy = new ADLDuration();
+        legacy.mDuration = 3661L; // legacy persisted seconds
+
+        ADLDuration fresh = new ADLDuration(IDuration.FORMAT_SCHEMA, "PT1H1M1S");
+
+        assertEquals("PT1H1M1S", legacy.format(IDuration.FORMAT_SCHEMA));
+        assertEquals("PT1H1M1S", fresh.format(IDuration.FORMAT_SCHEMA));
+        assertEquals("3661.0", legacy.format(IDuration.FORMAT_SECONDS));
+        assertEquals(IDuration.EQ, legacy.compare(fresh));
+    }
+}


### PR DESCRIPTION
## Summary
- store ADLDuration schema durations in seconds to match existing records
- adjust formatting and comparison logic to work with second-based storage
- add unit tests for API and impl modules covering new and legacy durations

## Testing
- `mvn -pl scormplayer/scorm-api test` *(fails: missing snapshot dependencies)*
- `mvn -pl scormplayer/scorm-impl/adl test` *(fails: missing snapshot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68fa7958562c8328a8a347feea78abb0