### PR TITLE
Fix temporary blob deletion error handling

### DIFF
--- a/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/BlobStoreFileSystemHandler.java
+++ b/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/BlobStoreFileSystemHandler.java
@@ -275,9 +275,9 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
                                     if (!toDelete.delete() && toDelete.exists()) {
                                         log.warn("Failed to delete temporary blob file {}", toDelete.getAbsolutePath());
                                     }
-                                } catch (IOException e) {
+                                } catch (SecurityException e) {
                                     log.warn("Error deleting temporary blob file {}", toDelete.getAbsolutePath(), e);
-                                    deletionIoEx = e;
+                                    deletionIoEx = new IOException("Error deleting temporary blob file " + toDelete.getAbsolutePath(), e);
                                 } catch (RuntimeException e) {
                                     log.warn("Error deleting temporary blob file {}", toDelete.getAbsolutePath(), e);
                                     deletionRtEx = e;


### PR DESCRIPTION
## Summary
- convert the unreachable IOException catch when deleting temporary blob files into a SecurityException handler
- wrap any SecurityException thrown during deletion in an IOException so the caller is notified consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffcdbbec008328997442d8c388c3ce